### PR TITLE
Change static website cloudfront from rest to website endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # terraform-personal-website
 Infrastructure repo for the creation of a personal website.
+
+## todo
+
+* Change static website module cloudfront distribution from website endpoint to REST API endpoint, add Lambda@Edge to change requests from /item to /item/index.html
+    * https://medium.com/@p_stotz/static-website-hosting-leverage-aws-s3-with-cloudfront-route53-acm-and-lambda-edge-8c781bc3b390
+    * https://blog.heyitschris.com/posts/hugo-on-aws-s3-cloudfront-route53/
+    * https://sanderknape.com/2020/02/building-a-static-serverless-website-using-s3-cloudfront/
+    * Alternatively, add `Referrer` header and restrict bucket to that
+    * This makes the website more secure and means no one can access the S3 bucket directly

--- a/modules/static_website/main.tf
+++ b/modules/static_website/main.tf
@@ -1,6 +1,12 @@
 resource "aws_s3_bucket" "web_statics" {
   bucket = var.bucket_name
-  acl    = "private"
+
+  acl = "public-read"
+
+  website {
+    index_document = "index.html"
+    error_document = "index.html"
+  }
 }
 
 data "aws_iam_policy_document" "s3_policy" {
@@ -10,7 +16,7 @@ data "aws_iam_policy_document" "s3_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.this.iam_arn]
+      identifiers = ["*"]
     }
   }
 }


### PR DESCRIPTION
- Cannot use /item must use /item/index.html instead, this fixes that
- This makes it less secure. The other solution is to use Lambda@Edge